### PR TITLE
Approximate LSTF with 8 FIFO queues.

### DIFF
--- a/ns-allinone-2.35/ns-2.35/queue/lstf.cc
+++ b/ns-allinone-2.35/ns-2.35/queue/lstf.cc
@@ -123,7 +123,7 @@ Packet* LstfQueue::deque()
                 printf("%lf: Lstf: QueueID %d: Dequing packet from flow with id %d, slack %lld, seqno = %d, size = %d from control queue\n", Scheduler::instance().clock(), queueid_, iph->flowid(), iph->prio(), seqNo, HDR_CMN(pkt)->size()); 
 	      return pkt;
             } 
-	    for (int i = LSTF_NUM_QUEUES; i >= 1; i--) {
+	    for (int i = 1; i <= LSTF_NUM_QUEUES; i--) {
                   if ((bin_[i].q_)->length() > 0) {
                       //if control queue empty, work on data queue
 	              Packet *pkt;

--- a/ns-allinone-2.35/ns-2.35/queue/lstf.h
+++ b/ns-allinone-2.35/ns-2.35/queue/lstf.h
@@ -15,7 +15,7 @@
 #include "fstream"
 
 #define DEBUG 1
-
+#define LSTF_NUM_QUEUES 8
 
 struct bindesc {
         PacketQueue *q_;        // underlying FIFO queue
@@ -28,13 +28,13 @@ class LstfQueue : public Queue {
     LstfQueue();
 
   protected:
-    void insertPacketinSortedQueue(Packet* pkt);
     void enque(Packet* pkt);
     int dropPacket(int pr);
     double txtime(Packet* p);
     Packet* deque();
    
-    bindesc bin_[2];
+    bindesc bin_[1 + LSTF_NUM_QUEUES];
+    long int q_bounds_[1 + LSTF_NUM_QUEUES];
 
     int curlen_;	    // the total occupancy of all bins in packets
     int debug_;


### PR DESCRIPTION
1. 8 FIFO queues are used instead of a single priority queue in the LstfQueue class.
2. The priorities of these queues can be passed in as arguments using the binding mechanism. The priority bounds are initialized in the queue's constructor.